### PR TITLE
Fix #20: Register all models in admin across apps

### DIFF
--- a/backend/apps/accounts/admin.py
+++ b/backend/apps/accounts/admin.py
@@ -1,0 +1,5 @@
+from django.contrib import admin
+from .models import UserProfile
+
+# UserProfile model from accounts app is registered here.
+admin.site.register(UserProfile)

--- a/backend/apps/biodiversity/admin.py
+++ b/backend/apps/biodiversity/admin.py
@@ -1,0 +1,6 @@
+from django.contrib import admin
+from .models import Place, BiodiversityRecord
+
+# Place and BiodiversityRecord models from biodiversity app are registered here.
+admin.site.register(Place)
+admin.site.register(BiodiversityRecord)

--- a/backend/apps/reports/admin.py
+++ b/backend/apps/reports/admin.py
@@ -1,0 +1,6 @@
+from django.contrib import admin
+from .models import Measurement, Observation
+
+# Measurement and Observation models from reports app are registered here.
+admin.site.register(Measurement)
+admin.site.register(Observation)

--- a/backend/apps/taxonomy/admin.py
+++ b/backend/apps/taxonomy/admin.py
@@ -1,0 +1,7 @@
+from django.contrib import admin
+from .models import Family, Genus, Species
+
+# Family, Genus, and Species models from taxonomy app are registered here.
+admin.site.register(Family)
+admin.site.register(Genus)
+admin.site.register(Species)


### PR DESCRIPTION

### Description:
This PR addresses [Issue #20](https://github.com/OmdenaAI/GibdetColombiaChapter_UrbanTreeObservatory/issues/20) by registering all models in the Django admin interface across the relevant apps (`accounts`, `biodiversity`, `reports`, and `taxonomy`). This ensures that all models are accessible and manageable via the Django admin panel.

---

### Changes Made:
1. **Accounts App**:
   - Registered the `UserProfile` model in admin.py.

2. **Biodiversity App**:
   - Registered the `Place` and `BiodiversityRecord` models in admin.py.

3. **Reports App**:
   - Registered the `Measurement` and `Observation` models in admin.py.

4. **Taxonomy App**:
   - Registered the `Family`, `Genus`, and `Species` models in admin.py.

---

### Related Issue:
Closes #20

---

- Let me know if further adjustments are needed!