### PR TITLE
Added i18n support and translation strategy documentation

### DIFF
--- a/backend/config/settings/base.py
+++ b/backend/config/settings/base.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 
+from django.utils.translation import gettext_lazy as _
+
 import environ
 
 # Initialize environment variables
@@ -48,13 +50,14 @@ MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
     "whitenoise.middleware.WhiteNoiseMiddleware",  # Serving static files
     "django.contrib.sessions.middleware.SessionMiddleware",
+    "django.middleware.locale.LocaleMiddleware",  # Language detection 
     "corsheaders.middleware.CorsMiddleware",  # CORS support
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
-    "allauth.account.middleware.AccountMiddleware",
+    "allauth.account.middleware.AccountMiddleware",  # Django AllAuth
 ]
 
 ROOT_URLCONF = "config.urls"
@@ -133,10 +136,20 @@ LEAFLET_CONFIG = {
 }
 
 # Internationalization
-LANGUAGE_CODE = "en-us"
-TIME_ZONE = "America/Bogota"  # Colombia time zone
+LANGUAGE_CODE = "es"  # Default language
+TIME_ZONE = "America/Bogota"  # Colombia timezone
 USE_I18N = True
+USE_L10N = True
 USE_TZ = True
+
+LANGUAGES = [
+    ("es", _("Spanish")),
+    ("en", _("English")),
+]
+
+LOCALE_PATHS = [
+    BASE_DIR / "locale",
+]
 
 # Static files (CSS, JavaScript, Images)
 STATIC_URL = "/static/"

--- a/docs/i18n-strategy-guide.md
+++ b/docs/i18n-strategy-guide.md
@@ -1,0 +1,583 @@
+# Internationalization (i18n) Strategy Guide
+
+This document outlines the comprehensive internationalization strategy for the Urban Tree Observatory project, which uses Django, Django REST Framework (DRF), and Angular.
+
+## Table of Contents
+
+1. [Core Principles](#core-principles)
+2. [Backend (Django/DRF) Implementation](#backend-djangodrf-implementation)
+3. [Frontend (Angular) Implementation](#frontend-angular-implementation)
+4. [API Communication Strategy](#api-communication-strategy)
+5. [Database and Data Import Strategy](#database-and-data-import-strategy)
+6. [Workflow for Adding/Updating Translations](#workflow-for-addingupdating-translations)
+7. [Testing i18n Implementation](#testing-i18n-implementation)
+8. [Best Practices and Common Pitfalls](#best-practices-and-common-pitfalls)
+
+## Core Principles
+
+- **Code in English**: All code, variable names, comments, and constants are in English
+- **Short, language-neutral codes in database**: Use codes like `NA`, `CU` instead of words
+- **Default user interface in Spanish**: Primary audience is Spanish-speaking
+- **Support for English UI**: Secondary language support for international users
+- **Separation of code from displayable text**: All user-facing text should be translatable
+
+## Backend (Django/DRF) Implementation
+
+### Django Settings Configuration
+
+```python
+# settings.py
+LANGUAGE_CODE = "es"  # Default language
+TIME_ZONE = "America/Bogota"  # Colombia timezone
+USE_I18N = True
+USE_L10N = True
+USE_TZ = True
+
+LANGUAGES = [
+    ("es", _("Spanish")),
+    ("en", _("English")),
+]
+
+LOCALE_PATHS = [
+    BASE_DIR / "locale",
+]
+
+MIDDLEWARE = [
+    # ... other middleware
+    "django.middleware.locale.LocaleMiddleware",  # Required for language detection
+    # ... rest of middleware
+]
+```
+
+### TextChoices Implementation
+
+Correct approach for TextChoices:
+
+```python
+# WRONG - Mixed Spanish/English and no translations
+class EstablishmentMeans(models.TextChoices):
+    NATIVA = "Nativa", "Native"
+    CULTIVADA = "Cultivada", "Cultivated"
+    # ...
+
+# CORRECT - English constants, neutral codes, translatable strings
+from django.utils.translation import gettext_lazy as _
+
+class EstablishmentMeans(models.TextChoices):
+    NATIVE = "NA", _("native")
+    CULTIVATED = "CU", _("cultivated") 
+    NOT_IDENTIFIED = "NI", _("not identified")
+    NATIVE_CULTIVATED = "NC", _("native | cultivated")
+    NATURALIZED = "NU", _("naturalized")
+    ENDEMIC = "EN", _("endemic")
+    NATURALIZED_CULTIVATED = "NL", _("naturalized | cultivated")
+```
+
+### Text Capitalization and Style
+
+We follow specific capitalization conventions for different types of text in our application. See our [Translation and Text Style Guide](./translation-style-guide.md) for detailed guidelines on:
+
+- Capitalization for different text types (field labels, error messages, etc.)
+- Punctuation in translatable strings
+- Formatting conventions for dates, numbers, and units
+- Handling technical terminology
+
+Consistency in these areas significantly improves the user experience and simplifies the translation process.
+
+### Using Translation Functions
+
+Two main translation functions:
+
+1. **gettext_lazy**: For model definitions, admin configurations
+
+   ```python
+   from django.utils.translation import gettext_lazy as _
+   
+   class MyModel(models.Model):
+       name = models.CharField(_("name"), max_length=100)
+   ```
+
+2. **gettext**: For immediate translation in views, form methods
+
+   ```python
+   from django.utils.translation import gettext as _
+   
+   def clean_email(self):
+       if error:
+           raise ValidationError(_("Invalid email address"))
+   ```
+
+### Django Admin Configuration
+
+```python
+from django.utils.translation import gettext_lazy as _
+
+class SpeciesAdmin(admin.ModelAdmin):
+    fieldsets = [
+        (_("Taxonomy"), {
+            "fields": ["family", "genus", "name", "scientific_name"]
+        }),
+        (_("Classification"), {
+            "fields": ["origin", "iucn_status", "growth_habit"]
+        }),
+    ]
+    list_display = ["scientific_name", "get_origin_display"]
+    list_filter = ["origin", "iucn_status"]
+    search_fields = ["name", "scientific_name"]
+```
+
+### DRF Serializers
+
+```python
+from django.utils.translation import gettext_lazy as _
+
+class SpeciesSerializer(serializers.ModelSerializer):
+    # Add display text for choice fields
+    origin_display = serializers.CharField(source="get_origin_display", read_only=True)
+    
+    class Meta:
+        model = Species
+        fields = ["id", "name", "scientific_name", "origin", "origin_display"]
+        
+    def validate_name(self, value):
+        if not value:
+            raise serializers.ValidationError(_("Species name cannot be empty"))
+        return value
+```
+
+### Custom Fields for Localized Responses
+
+```python
+class LocalizedChoiceField(serializers.ChoiceField):
+    """Choice field that returns localized display values"""
+    def to_representation(self, value):
+        if value in ("", None):
+            return value
+        # Get the translated display text
+        return str(self._choices.get(value, value))
+```
+
+## Frontend (Angular) Implementation
+
+### Setup ngx-translate
+
+1. Install the packages:
+
+   ```bash
+   npm install @ngx-translate/core @ngx-translate/http-loader
+   ```
+
+2. Configure in app module:
+
+   ```typescript
+   // app.module.ts
+   import { TranslateModule, TranslateLoader } from '@ngx-translate/core';
+   import { TranslateHttpLoader } from '@ngx-translate/http-loader';
+   import { HttpClient } from '@angular/common/http';
+   
+   export function HttpLoaderFactory(http: HttpClient) {
+     return new TranslateHttpLoader(http, './assets/i18n/', '.json');
+   }
+   
+   @NgModule({
+     imports: [
+       // Other imports
+       TranslateModule.forRoot({
+         loader: {
+           provide: TranslateLoader,
+           useFactory: HttpLoaderFactory,
+           deps: [HttpClient]
+         },
+         defaultLanguage: 'es'
+       })
+     ]
+   })
+   export class AppModule { }
+   ```
+
+3. Initialize in app component:
+
+   ```typescript
+   // app.component.ts
+   import { TranslateService } from '@ngx-translate/core';
+   
+   @Component({/* ... */})
+   export class AppComponent {
+     constructor(private translate: TranslateService) {
+       // Default and fallback language
+       translate.setDefaultLang('es');
+       
+       // Get saved language or use browser language
+       const savedLang = localStorage.getItem('language') || 
+                         translate.getBrowserLang() || 
+                         'es';
+       translate.use(savedLang);
+     }
+   }
+   ```
+
+### Translation Files Structure
+
+Create translation files in `/assets/i18n/`:
+
+```json
+// es.json
+{
+  "common": {
+    "buttons": {
+      "save": "Guardar",
+      "cancel": "Cancelar",
+      "edit": "Editar",
+      "delete": "Eliminar"
+    }
+  },
+  "species": {
+    "fields": {
+      "scientificName": "Nombre científico",
+      "commonName": "Nombre común"
+    },
+    "origin": {
+      "native": "Nativa",
+      "exotic": "Exótica",
+      "unknown": "Desconocido"
+    }
+  }
+}
+```
+
+```json
+// en.json
+{
+  "common": {
+    "buttons": {
+      "save": "Save",
+      "cancel": "Cancel",
+      "edit": "Edit",
+      "delete": "Delete"
+    }
+  },
+  "species": {
+    "fields": {
+      "scientificName": "Scientific name",
+      "commonName": "Common name"
+    },
+    "origin": {
+      "native": "Native",
+      "exotic": "Exotic",
+      "unknown": "Unknown"
+    }
+  }
+}
+```
+
+### Using Translations in Angular
+
+1. In templates:
+
+   ```html
+   <!-- Simple strings -->
+   <button>{{ 'common.buttons.save' | translate }}</button>
+   
+   <!-- With parameters -->
+   <p>{{ 'species.count' | translate:{ count: totalSpecies } }}</p>
+   
+   <!-- HTML content -->
+   <div [innerHTML]="'species.description' | translate"></div>
+   ```
+
+2. In TypeScript:
+
+   ```typescript
+   import { TranslateService } from '@ngx-translate/core';
+   
+   constructor(private translateService: TranslateService) {}
+   
+   showMessage() {
+     const message = this.translateService.instant('messages.success');
+     // Use message in alerts, etc.
+   }
+   
+   switchLanguage(lang: string) {
+     this.translateService.use(lang);
+     localStorage.setItem('language', lang);
+   }
+   ```
+
+## API Communication Strategy
+
+### Language Detection and Switching
+
+1. Setting language in Angular HTTP requests:
+
+   ```typescript
+   // api.service.ts
+   import { HttpClient, HttpHeaders } from '@angular/common/http';
+   import { TranslateService } from '@ngx-translate/core';
+   
+   @Injectable()
+   export class ApiService {
+     constructor(
+       private http: HttpClient,
+       private translateService: TranslateService
+     ) {}
+     
+     getHeaders(): HttpHeaders {
+       return new HttpHeaders({
+         'Accept-Language': this.translateService.currentLang
+       });
+     }
+     
+     getSpecies() {
+       return this.http.get('/api/species/', { headers: this.getHeaders() });
+     }
+   }
+   ```
+
+2. Processing language header in Django:
+
+   ```python
+   # The LocaleMiddleware will handle this automatically
+   # Just ensure it's properly configured in settings.py
+   ```
+
+### API Response Localization
+
+Strategy 1: Return both code and display value:
+
+```json
+{
+  "id": 1,
+  "name": "Quercus ilex",
+  "origin": {
+    "code": "NA",
+    "display": "Nativa" 
+  }
+}
+```
+
+Strategy 2: Expand serializer with display values:
+
+```python
+class SpeciesSerializer(serializers.ModelSerializer):
+    origin_display = serializers.CharField(source="get_origin_display", read_only=True)
+    
+    class Meta:
+        model = Species
+        fields = ["id", "name", "origin", "origin_display"]
+```
+
+## Database and Data Import Strategy
+
+### Handling CSV Imports with Spanish Data
+
+Use mapping dictionaries to convert Spanish terms to database codes:
+
+```python
+# mappings.py
+from apps.taxonomy.models import Species
+
+ORIGIN_MAPPINGS = {
+    "Nativa": Species.Origin.NATIVE,
+    "Exótica": Species.Origin.EXOTIC,
+    "Exotica": Species.Origin.EXOTIC,
+    "Desconocido": Species.Origin.UNKNOWN
+}
+
+def get_mapped_value(value, mapping_dict, default=None):
+    """Get mapped value from dictionary with case-insensitive lookup"""
+    if not value:
+        return default
+        
+    # Try direct lookup
+    if value in mapping_dict:
+        return mapping_dict[value]
+    
+    # Try case-insensitive lookup
+    value_lower = value.lower()
+    for k, v in mapping_dict.items():
+        if k.lower() == value_lower:
+            return v
+    
+    return default
+```
+
+Using the mappings during import:
+
+```python
+def process_taxonomy_data(data):
+    for row in data:
+        origin = get_mapped_value(
+            row.get("origin", ""),
+            ORIGIN_MAPPINGS,
+            Species.Origin.UNKNOWN
+        )
+        
+        species = Species.objects.create(
+            name=row.get("name", ""),
+            origin=origin,
+            # Other fields...
+        )
+```
+
+### Database Content Guidelines
+
+1. **Enumerated values**: Store as neutral codes (e.g., "NA" not "Nativa")
+2. **Free text user input**: Store as-is (in Spanish if user entered in Spanish)
+3. **Scientific names**: Store as-is (universal nomenclature)
+4. **Generated responses**: Don't store translated text, generate at runtime
+
+## Workflow for Adding/Updating Translations
+
+### Django Translations
+
+1. Mark strings for translation in code:
+
+   ```python
+   from django.utils.translation import gettext_lazy as _
+   
+   title = _("Species List")
+   ```
+
+2. Extract messages:
+
+   ```bash
+   python manage.py makemessages -l es
+   python manage.py makemessages -l en
+   ```
+
+3. Edit translation files in `locale/[lang]/LC_MESSAGES/django.po`
+
+4. Compile messages:
+
+   ```bash
+   python manage.py compilemessages
+   ```
+
+### Angular Translations
+
+1. Add new keys to translation files in `/assets/i18n/`
+
+2. Use translations in components
+
+3. Consider using translation management tools for larger projects:
+   - BabelEdit
+   - Lokalise
+   - POEditor
+
+## Testing i18n Implementation
+
+### Backend Testing
+
+```python
+from django.test import TestCase
+from django.utils import translation
+from apps.taxonomy.models import Species
+from apps.taxonomy.serializers import SpeciesSerializer
+
+class I18nTestCase(TestCase):
+    def setUp(self):
+        self.species = Species.objects.create(
+            name="Oak",
+            origin=Species.Origin.NATIVE
+        )
+    
+    def test_origin_display_localization(self):
+        # Test Spanish translation
+        with translation.override("es"):
+            serializer = SpeciesSerializer(self.species)
+            self.assertEqual(serializer.data["origin_display"], "Nativa")
+        
+        # Test English translation
+        with translation.override("en"):
+            serializer = SpeciesSerializer(self.species)
+            self.assertEqual(serializer.data["origin_display"], "Native")
+```
+
+### Frontend Testing
+
+```typescript
+import { TestBed } from '@angular/core/testing';
+import { TranslateModule, TranslateService } from '@ngx-translate/core';
+
+describe('TranslationService', () => {
+  let translateService: TranslateService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        TranslateModule.forRoot()
+      ]
+    });
+    
+    translateService = TestBed.inject(TranslateService);
+    translateService.setTranslation('es', {
+      'species.origin.native': 'Nativa'
+    });
+    translateService.setTranslation('en', {
+      'species.origin.native': 'Native'
+    });
+    translateService.setDefaultLang('es');
+  });
+
+  it('should translate according to current language', () => {
+    translateService.use('es');
+    expect(translateService.instant('species.origin.native')).toBe('Nativa');
+    
+    translateService.use('en');
+    expect(translateService.instant('species.origin.native')).toBe('Native');
+  });
+});
+```
+
+## Best Practices and Common Pitfalls
+
+### Best Practices
+
+1. **Avoid string concatenation** for translated text:
+
+   ```python
+   # BAD
+   message = _("Hello") + ", " + user.name
+   
+   # GOOD - With placeholders
+   message = _("Hello, %(name)s") % {"name": user.name}
+   ```
+
+2. **Use context for ambiguous terms**:
+
+   ```python
+   from django.utils.translation import pgettext_lazy
+   
+   # "Trunk" can mean different things
+   tree_trunk = pgettext_lazy("tree part", "trunk")
+   elephant_trunk = pgettext_lazy("elephant body part", "trunk")
+   ```
+
+3. **Keep translations organized** with namespaces:
+
+   ```python
+   species.fields.name
+   species.actions.create
+   common.buttons.save
+   ```
+
+4. **Document specialized terminology** in a glossary for translators
+
+### Common Pitfalls
+
+1. **Hardcoded strings** in templates or code
+2. **Using non-lazy translation** in model definitions
+3. **Forgetting to compile messages** after updates
+4. **Not handling pluralization** correctly
+5. **Assuming translated text length** will be similar to original
+6. **Not escaping variables** in translated strings
+
+### Performance Considerations
+
+1. **Lazy loading** of translation files in Angular
+2. **Caching API responses** with language-specific keys
+3. **Server-side rendering** with correct initial language
+
+---
+
+This strategy provides a comprehensive approach to internationalization for the Urban Tree Observatory project. By following these guidelines, the application will provide a consistent experience for both Spanish and English users while maintaining clean, maintainable code.

--- a/docs/translation-style-guide.md
+++ b/docs/translation-style-guide.md
@@ -1,0 +1,256 @@
+# Translation and Text Style Guide
+
+This document outlines the text and translation style standards for the Urban Tree Observatory project, covering capitalization, punctuation, formatting, and general language guidelines for both English and Spanish.
+
+## Table of Contents
+
+1. [Capitalization Conventions](#capitalization-conventions)
+2. [Punctuation Guidelines](#punctuation-guidelines)
+3. [Formatting Standards](#formatting-standards)
+4. [Technical Terminology](#technical-terminology)
+5. [Language-Specific Considerations](#language-specific-considerations)
+6. [Examples and Common Cases](#examples-and-common-cases)
+
+## Capitalization Conventions
+
+We follow different capitalization rules depending on the context and purpose of the text:
+
+### Field Labels, Choice Options, and UI Elements
+
+**Use lowercase** for field labels, model attributes, choice options, and other short UI elements:
+
+```python
+# Django model fields
+name = models.CharField(_("species name"), max_length=100)
+date_recorded = models.DateField(_("recording date"), null=True)
+
+# Choice options
+class Origin(models.TextChoices):
+    NATIVE = "NA", _("native")
+    EXOTIC = "EX", _("exotic")
+    UNKNOWN = "UN", _("unknown")
+
+# Meta information
+class Meta:
+    verbose_name = _("species")
+    verbose_name_plural = _("species")
+```
+
+**Spanish translation example:**
+
+- "species name" → "nombre de la especie"
+- "native" → "nativa"
+- "species" → "especie"
+
+### Sentences, Error Messages, and Notifications
+
+**Use sentence case** (capitalize first letter only) for complete sentences, error messages, alerts, and notifications:
+
+```python
+# Error messages
+raise ValidationError(_("This field is required"))
+
+# Success messages
+messages.success(request, _("Species was successfully updated"))
+
+# Instructions
+help_text=_("Enter the scientific name including genus and species")
+```
+
+**Spanish translation example:**
+
+- "This field is required" → "Este campo es obligatorio"
+- "Species was successfully updated" → "La especie fue actualizada correctamente"
+
+### Titles and Headings
+
+**Use sentence case** for page titles, section headings, and dialog titles:
+
+```python
+# Page title
+page_title = _("Create new species record")
+
+# Section header
+section_header = _("Taxonomy information")
+```
+
+**Spanish translation example:**
+
+- "Create new species record" → "Crear nuevo registro de especie"
+- "Taxonomy information" → "Información taxonómica"
+
+## Punctuation Guidelines
+
+### Ending Punctuation
+
+- **Omit trailing periods** for field labels, column headers, and short phrases
+- **Include trailing periods** for complete sentences, including error messages and help text
+
+```python
+# Without period (field label)
+species_name = models.CharField(_("scientific name"), max_length=100)
+
+# With period (complete sentence in help text)
+help_text=_("Enter the full scientific name with genus and species.")
+```
+
+### Colons in Labels
+
+- **Omit colons** in field labels and form inputs - the UI framework will add these as needed
+- If a label needs further explanation, use a separate help text field rather than adding it to the label
+
+```python
+# Correct
+name_label = _("scientific name")
+name_help = _("Enter in format: Genus species")
+
+# Incorrect
+name_label = _("scientific name: enter in format Genus species")
+```
+
+### Quotation Marks
+
+- Use double quotes (`"`) for quoted content in English
+- Use angular quotes (`«` and `»`) for quoted content in Spanish
+
+## Formatting Standards
+
+### Dates and Times
+
+- Follow locale-specific formatting through Django's localization system
+- Spell out month names in long formats
+- Use 24-hour format for time representation
+
+**English examples:**
+
+- Short date: "Apr 15, 2025"
+- Long date: "April 15, 2025"
+- Time: "14:30"
+
+**Spanish examples:**
+
+- Short date: "15 abr 2025"
+- Long date: "15 de abril de 2025"
+- Time: "14:30"
+
+### Numbers and Measurements
+
+- Use the metric system for all measurements
+- Follow locale-specific conventions for decimal and thousands separators
+- Include a space between number and unit
+
+**English examples:**
+
+- Decimal: "3.5 m"
+- Large number: "1,500 trees"
+
+**Spanish examples:**
+
+- Decimal: "3,5 m"
+- Large number: "1.500 árboles"
+
+## Technical Terminology
+
+### Scientific Names
+
+- Always capitalize genus, lowercase species: "Quercus ilex"
+- Do not translate scientific names
+- Italicize in UI display (handled via CSS, not in translation strings)
+
+### Domain-Specific Terms
+
+Maintain a consistent glossary for domain-specific terms across languages:
+
+| English | Spanish | Notes |
+|---------|---------|-------|
+| carbon sequestration | secuestro de carbono | |
+| diameter at breast height | diámetro a la altura del pecho | Abbreviated as DAP in Spanish |
+| native | nativa | Plant origin |
+| exotic | exótica | Plant origin |
+| canopy | dosel | Tree structure |
+| trunk | tronco | Tree structure |
+
+## Language-Specific Considerations
+
+### English
+
+- Be concise and direct
+- Use active voice when possible
+- Avoid jargon and complex terminology outside of scientific contexts
+
+### Spanish
+
+- Spanish uses more words than English for the same concept - allow for text expansion
+- Gender agreement is important - be consistent with masculine/feminine forms
+- Use formal "usted" form for instructions and messages
+- Avoid Anglicisms when Spanish terms exist
+
+## Examples and Common Cases
+
+### Form Field Labels
+
+| Context | English | Spanish |
+|---------|---------|---------|
+| Field label | scientific name | nombre científico |
+| Field label | recording date | fecha de registro |
+| Field label | trunk height (m) | altura del tronco (m) |
+
+### Choice Fields
+
+| Context | English | Spanish |
+|---------|---------|---------|
+| Origin choice | native | nativa |
+| Status choice | endangered | en peligro |
+| Condition choice | good | bueno |
+
+### Messages
+
+| Context | English | Spanish |
+|---------|---------|---------|
+| Success | Changes saved successfully. | Cambios guardados correctamente. |
+| Error | This field is required. | Este campo es obligatorio. |
+| Confirmation | Are you sure you want to delete this record? | ¿Está seguro de que desea eliminar este registro? |
+
+### Page Titles
+
+| Context | English | Spanish |
+|---------|---------|---------|
+| List page | Species list | Lista de especies |
+| Detail page | Species details | Detalles de la especie |
+| Form page | Edit species | Editar especie |
+
+## Practical Implementation
+
+### In Django Templates
+
+```html
+{% trans "species list" %}  <!-- field label - lowercase -->
+{% trans "Species record was created successfully." %}  <!-- sentence - sentence case -->
+```
+
+### In Python Code
+
+```python
+# Field label - lowercase
+name = models.CharField(_("common name"), max_length=100)
+
+# Error message - sentence case
+raise ValidationError(_("Please enter a valid value."))
+```
+
+### In Angular Templates
+
+```html
+<!-- Field label - lowercase -->
+<label>{{ 'species.fields.commonName' | translate }}</label>
+
+<!-- Button - lowercase -->
+<button>{{ 'common.buttons.save' | translate }}</button>
+
+<!-- Message - sentence case -->
+<p class="error">{{ 'validation.required' | translate }}</p>
+```
+
+---
+
+By following these guidelines consistently, we ensure that both the English and Spanish versions of the application maintain a professional appearance and natural language flow while simplifying the translation process.


### PR DESCRIPTION
This PR proposes standards for internationalization and localization, including various examples in English and Spanish.

- Updated Django settings to include internationalization (i18n) configurations: 
  - Added `LocaleMiddleware` to middleware. 
  - Defined `LANGUAGES` and `LOCALE_PATHS`. 
  - Set default `LANGUAGE_CODE` to Spanish (`es`).
- Created `i18n-strategy-guide.md` to outline the internationalization strategy.
- Created `translation-style-guide.md` to define text and translation style standards.

Closes #23