### PR TITLE
Update examples in i18n strategy and translation style guides

### DIFF
--- a/docs/i18n-strategy-guide.md
+++ b/docs/i18n-strategy-guide.md
@@ -55,7 +55,7 @@ Correct approach for TextChoices:
 
 ```python
 # WRONG - Mixed Spanish/English and no translations
-class EstablishmentMeans(models.TextChoices):
+class Origin(models.TextChoices):
     NATIVA = "Nativa", "Native"
     CULTIVADA = "Cultivada", "Cultivated"
     # ...
@@ -63,7 +63,7 @@ class EstablishmentMeans(models.TextChoices):
 # CORRECT - English constants, neutral codes, translatable strings
 from django.utils.translation import gettext_lazy as _
 
-class EstablishmentMeans(models.TextChoices):
+class Origin(models.TextChoices):
     NATIVE = "NA", _("native")
     CULTIVATED = "CU", _("cultivated") 
     NOT_IDENTIFIED = "NI", _("not identified")

--- a/docs/translation-style-guide.md
+++ b/docs/translation-style-guide.md
@@ -25,10 +25,16 @@ name = models.CharField(_("species name"), max_length=100)
 date_recorded = models.DateField(_("recording date"), null=True)
 
 # Choice options
-class Origin(models.TextChoices):
-    NATIVE = "NA", _("native")
-    EXOTIC = "EX", _("exotic")
-    UNKNOWN = "UN", _("unknown")
+class IUCNStatus(models.TextChoices):
+    DATA_DEFICIENT = "DD", _("data deficient")
+    LEAST_CONCERN = "LC", _("least concern")
+    NEAR_THREATENED = "NT", _("near threatened")
+    VULNERABLE = "VU", _("vulnerable")
+    ENDANGERED = "EN", _("endangered")
+    CRITICALLY_ENDANGERED = "CR", _("critically endangered")
+    EXTINCT_IN_WILD = "EW", _("extinct in the wild")
+    EXTINCT = "EX", _("extinct")
+    NOT_EVALUATED = "NE", _("not evaluated")
 
 # Meta information
 class Meta:


### PR DESCRIPTION
- Renamed `EstablishmentMeans` to `Origin` in `i18n-strategy-guide.md`.
- Updated `translation-style-guide.md` to replace `Origin` with `IUCNStatus`.