### PR TITLE
Simplified climate data import and fixed documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,11 +71,12 @@ docker compose exec backend python manage.py import_initial_data
 # Using custom URLs
 docker compose exec backend python manage.py import_initial_data \
   --taxonomy-url=https://example.com/taxonomy.csv \
-  --place-url=https://example.com/places.csv \
+  --places-url=https://example.com/places.csv \
   --biodiversity-url=https://example.com/biodiversity.csv \
   --measurements-url=https://example.com/measurements.csv \
   --observations-url=https://example.com/observations.csv \
-  --traits-url=https://example.com/traits.csv
+  --traits-url=https://example.com/traits.csv \
+  --climate-url=https://example.com/climate.csv
 
 # Using local files in a directory mounted to the container
 docker compose exec backend python manage.py import_initial_data --local-dir=/path/to/data
@@ -140,10 +141,10 @@ pre-commit run --all-files
 
 ```bash
 # Backend tests
-docker-compose exec backend python manage.py test
+docker compose exec backend python manage.py test
 
 # Frontend tests
-docker-compose exec frontend ng test
+docker compose exec frontend ng test
 ```
 
 ## API Documentation

--- a/scripts/explore_csv_data.py
+++ b/scripts/explore_csv_data.py
@@ -71,7 +71,7 @@ TEXT_CHOICE_FIELDS = {
     ],
     "places.csv": [],
     "traits.csv": [],
-    "climate.csv": [],
+    "climate.csv": ["sensordescription", "measureunit"],
 }
 
 # Other interesting fields to analyze (not TextChoices)
@@ -1167,7 +1167,7 @@ def main():
         "--data-dir", required=True, help="Directory containing CSV files"
     )
     parser.add_argument(
-        "--output-dir", default="scripts/data", help="Directory for output reports"
+        "--output-dir", default="data", help="Directory for output reports"
     )
     args = parser.parse_args()
 


### PR DESCRIPTION
Summary of changes:

- Corrected `--place-url` to `--places-url` in README.md.
- Added `--climate-url` example to README.md.
- Simplified climate data import logic in `import_initial_data.py`:
    - Removed coordinate normalization for BATALLON ROOKE station.
    - Removed unused sensor mapping logic.
- Updated `explore_csv_data.py` to include `sensordescription` and `measureunit` for `climate.csv`.

Closes #69