### PR TITLE
refactor: move municipality foreign key from Climate to Station

### DIFF
--- a/backend/apps/climate/admin.py
+++ b/backend/apps/climate/admin.py
@@ -8,6 +8,7 @@ from .models import Station, Climate
 class StationAdmin(GISModelAdmin):
     list_display = ("code", "name")
     search_fields = ("name", "code")
+    raw_id_fields = ("municipality",)
     readonly_fields = ("id",)
 
 
@@ -16,17 +17,22 @@ class ClimateAdmin(admin.ModelAdmin):
     list_display = (
         "id",
         "station",
+        "station_municipality",
         "date",
         "sensor_display",
         "value",
         "measure_unit_display",
     )
-    list_filter = ("station", "sensor", "measure_unit", "date")
+    list_filter = ("station", "station__municipality", "sensor", "measure_unit", "date")
     search_fields = ("station__name", "station__code")
-    raw_id_fields = ("station", "municipality")
+    raw_id_fields = ("station",)
     readonly_fields = ("created_at", "updated_at")
     date_hierarchy = "date"
     list_per_page = 25
+
+    @admin.display(description="Municipality")
+    def station_municipality(self, obj):
+        return obj.station.municipality
 
     @admin.display(description="Sensor")
     def sensor_display(self, obj):

--- a/backend/apps/climate/migrations/0001_initial.py
+++ b/backend/apps/climate/migrations/0001_initial.py
@@ -22,6 +22,7 @@ class Migration(migrations.Migration):
                 ('code', models.IntegerField(unique=True, verbose_name='station code')),
                 ('name', models.CharField(max_length=100, verbose_name='station name')),
                 ('location', django.contrib.gis.db.models.fields.PointField(geography=True, srid=4326, verbose_name='location')),
+                ('municipality', models.ForeignKey(on_delete=django.db.models.deletion.PROTECT, related_name='stations', to='places.municipality', verbose_name='municipality')),
             ],
             options={
                 'verbose_name': 'weather station',
@@ -40,7 +41,6 @@ class Migration(migrations.Migration):
                 ('sensor', models.CharField(choices=[('t2m', 'air temperature at 2 m')], default='t2m', max_length=3, verbose_name='sensor description')),
                 ('value', models.FloatField(verbose_name='measured value')),
                 ('measure_unit', models.CharField(choices=[('°C', 'Celsius')], default='°C', max_length=2, verbose_name='measurement unit')),
-                ('municipality', models.ForeignKey(on_delete=django.db.models.deletion.PROTECT, related_name='climate_data', to='places.municipality', verbose_name='municipality')),
                 ('station', models.ForeignKey(on_delete=django.db.models.deletion.PROTECT, related_name='climate_data', to='climate.station', verbose_name='weather station')),
             ],
             options={

--- a/backend/apps/climate/models.py
+++ b/backend/apps/climate/models.py
@@ -10,6 +10,12 @@ class Station(models.Model):
     code = models.IntegerField(_("station code"), unique=True)
     name = models.CharField(_("station name"), max_length=100)
     location = gis_models.PointField(_("location"), srid=4326, geography=True)
+    municipality = models.ForeignKey(
+        Municipality,
+        on_delete=models.PROTECT,
+        related_name="stations",
+        verbose_name=_("municipality"),
+    )
 
     class Meta:
         verbose_name = _("weather station")
@@ -37,12 +43,6 @@ class Climate(BaseModel):
     class MeasureUnit(models.TextChoices):
         CELSIUS = "°C", _("Celsius")
 
-    municipality = models.ForeignKey(
-        Municipality,
-        on_delete=models.PROTECT,
-        related_name="climate_data",
-        verbose_name=_("municipality"),
-    )
     station = models.ForeignKey(
         Station,
         on_delete=models.PROTECT,

--- a/backend/apps/climate/serializers.py
+++ b/backend/apps/climate/serializers.py
@@ -9,10 +9,19 @@ class StationSerializer(serializers.ModelSerializer):
 
     longitude = serializers.FloatField(read_only=True)
     latitude = serializers.FloatField(read_only=True)
+    municipality = MunicipalitySerializer(read_only=True)
 
     class Meta:
         model = Station
-        fields = ["id", "code", "name", "location", "longitude", "latitude"]
+        fields = [
+            "id",
+            "code",
+            "name",
+            "location",
+            "longitude",
+            "latitude",
+            "municipality",
+        ]
 
 
 class StationGeoSerializer(GeoFeatureModelSerializer):
@@ -28,8 +37,7 @@ class ClimateSerializer(serializers.ModelSerializer):
     """Serializer for the Climate model."""
 
     station = StationSerializer(read_only=True)
-    municipality = MunicipalitySerializer(read_only=True)
-
+    municipality = MunicipalitySerializer(source="station.municipality", read_only=True)
     sensor_display = serializers.CharField(source="get_sensor_display", read_only=True)
     measure_unit_display = serializers.CharField(
         source="get_measure_unit_display", read_only=True

--- a/backend/apps/climate/views.py
+++ b/backend/apps/climate/views.py
@@ -105,7 +105,7 @@ class ClimateFilter(django_filters.FilterSet):
 class ClimateViewSet(viewsets.ReadOnlyModelViewSet):
     """API endpoint for Climate model."""
 
-    queryset = Climate.objects.select_related("station")
+    queryset = Climate.objects.select_related("station__municipality")
     serializer_class = ClimateSerializer
     permission_classes = [IsAuthenticatedOrReadOnly]
     filter_backends = [DjangoFilterBackend, filters.OrderingFilter]

--- a/backend/apps/climate/views.py
+++ b/backend/apps/climate/views.py
@@ -26,7 +26,7 @@ class StationFilter(django_filters.FilterSet):
 class StationViewSet(viewsets.ReadOnlyModelViewSet):
     """API endpoint for Station model."""
 
-    queryset = Station.select_related("municipality")
+    queryset = Station.objects.select_related("municipality")
     serializer_class = StationSerializer
     permission_classes = [IsAuthenticatedOrReadOnly]
     filter_backends = [

--- a/backend/apps/climate/views.py
+++ b/backend/apps/climate/views.py
@@ -19,13 +19,14 @@ class StationFilter(django_filters.FilterSet):
         fields = {
             "code": ["exact"],
             "name": ["exact", "icontains"],
+            "municipality": ["exact"],
         }
 
 
 class StationViewSet(viewsets.ReadOnlyModelViewSet):
     """API endpoint for Station model."""
 
-    queryset = Station.objects.all()
+    queryset = Station.select_related("municipality")
     serializer_class = StationSerializer
     permission_classes = [IsAuthenticatedOrReadOnly]
     filter_backends = [
@@ -95,16 +96,16 @@ class ClimateFilter(django_filters.FilterSet):
         model = Climate
         fields = {
             "station": ["exact"],
-            "municipality": ["exact"],
             "sensor": ["exact"],
             "measure_unit": ["exact"],
+            "station__municipality": ["exact"],
         }
 
 
 class ClimateViewSet(viewsets.ReadOnlyModelViewSet):
     """API endpoint for Climate model."""
 
-    queryset = Climate.objects.select_related("station", "municipality")
+    queryset = Climate.objects.select_related("station")
     serializer_class = ClimateSerializer
     permission_classes = [IsAuthenticatedOrReadOnly]
     filter_backends = [DjangoFilterBackend, filters.OrderingFilter]
@@ -127,7 +128,7 @@ class ClimateViewSet(viewsets.ReadOnlyModelViewSet):
             param in self.request.query_params
             for param in [
                 "station",
-                "municipality",
+                "station__municipality",
                 "date_from",
                 "date_to",
                 "sensor",

--- a/backend/apps/core/management/commands/import_initial_data.py
+++ b/backend/apps/core/management/commands/import_initial_data.py
@@ -840,7 +840,6 @@ class Command(BaseCommand):
 
         # Validate headers
         required_columns = {
-            "municipality_id",
             "stationcode",
             "stationname",
             "datetime",
@@ -879,6 +878,7 @@ class Command(BaseCommand):
                 code=row.stationcode,
                 name=row.stationname,
                 location=location,
+                municipality=self.ibague,
             )
             stations_batch.append(station)
 
@@ -907,7 +907,6 @@ class Command(BaseCommand):
                     station = station_map.get(row.stationcode)
 
                     climate_record = Climate(
-                        municipality=self.ibague,
                         station=station,
                         date=self.parse_date(row.datetime),
                         sensor=row.sensordescription,


### PR DESCRIPTION
- Removed the `municipality` foreign key from the `Climate` model.
- Added the `municipality` foreign key to the `Station` model.
- Updated the `ClimateAdmin` to display and filter by `station__municipality`.
- Adjusted the `ClimateSerializer` to use `station.municipality` for the `municipality` field.
- Modified the `StationSerializer` to include the `municipality` field.
- Updated the `StationFilter` and `ClimateFilter` to filter by `municipality` via `station__municipality`.
- Adjusted the `StationViewSet` and `ClimateViewSet` to use `select_related` for `municipality` where applicable.
- Updated the `import_initial_data` management command to set the `municipality` on `Station` instead of `Climate`.
- Removed the `municipality` field from the initial migration for the `Climate` model and added it to the `Station` model.

Fixes #93 