### PR TITLE
Updated initial data import instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,25 +62,15 @@ docker compose exec backend python manage.py createsuperuser
 
 ### Initial Data Import
 
-To import initial data into the database, run the following command:
+To import initial data into the database:
 
-```bash
-# Using the default Hugging Face URLs
-docker compose exec backend python manage.py import_initial_data
+1. Download the latest version of the CSV files from the project's shared Google Drive (ask the project lead or the team lead for the link).
+2. Save the files to `backend/data/csv` (*this directory is already git-ignored and the files will be instantly available inside the container at `/app/data/csv`*).
+3. Run the import command:
 
-# Using custom URLs
-docker compose exec backend python manage.py import_initial_data \
-  --taxonomy-url=https://example.com/taxonomy.csv \
-  --places-url=https://example.com/places.csv \
-  --biodiversity-url=https://example.com/biodiversity.csv \
-  --measurements-url=https://example.com/measurements.csv \
-  --observations-url=https://example.com/observations.csv \
-  --traits-url=https://example.com/traits.csv \
-  --climate-url=https://example.com/climate.csv
-
-# Using local files in a directory mounted to the container
-docker compose exec backend python manage.py import_initial_data --local-dir=/path/to/data
-```
+   ```bash
+   docker compose exec backend python manage.py import_initial_data --local-dir=data/csv
+   ```
 
 ## Project Structure
 


### PR DESCRIPTION
This should make it easier for everyone to populate the database. While we fix the Hugging Face default import command, this is the method at least three of us have used successfully. So, we also don't need that complicated and messy method with individual URLs. It may work, but we don't need it documented. 

I also simplified the steps from what I've been telling people to do. This was based on my limited understanding of Docker. Now, I understand that since we are binding the entire backend to the volume, we don't need to pass the `--build` flag as I've been doing.  We don't even need to restart the containers. The files *should* be instantly available.

Apprently, we don't need the 
- Simplified the instructions for importing initial data into the database.
- Removed examples using custom URLs and local files.
- Added steps to download CSV files from the shared Google Drive and use the `--local-dir` option.