### PR TITLE
Enhance Codecov integration and doc coverage reporting setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,10 @@ pre-commit run --all-files
 
 ```bash
 # Backend tests
-docker compose exec backend python manage.py test
+docker compose exec backend pytest
+
+# Backend tests with coverage
+docker compose exec backend pytest --cov=. --cov-config=.coveragerc
 
 # Frontend tests
 docker compose exec frontend ng test

--- a/backend/.coveragerc
+++ b/backend/.coveragerc
@@ -1,0 +1,25 @@
+[run]
+source = .
+omit =
+    */migrations/*
+    */tests/*
+    */admin.py
+    config/*
+    manage.py
+
+[report]
+exclude_lines =
+    pragma: no cover
+    def __repr__
+    def __str__
+    raise NotImplementedError
+    if self.debug:
+    if settings.DEBUG
+    raise ImportError
+    if 0:
+    if __name__ == .__main__.:
+    pass
+    raise NotImplementedError
+
+[html]
+directory = htmlcov

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,2 +1,6 @@
 # Data import files
 data/csv/
+
+# Coverage files
+.coverage
+htmlcov/

--- a/backend/README.md
+++ b/backend/README.md
@@ -95,18 +95,58 @@ docker compose exec backend python manage.py shell_plus
 
 ### Testing
 
-To run tests:
+#### Using Django's test runner
+
+To run tests with Django's built-in test runner:
 
 ```bash
 docker compose exec backend python manage.py test
 ```
 
+#### Using pytest (recommended)
+
+To run tests with pytest:
+
+```bash
+docker compose exec backend pytest
+```
+
+To run tests with verbose output:
+
+```bash
+docker compose exec backend pytest -v
+```
+
+#### Coverage
+
 To run tests with coverage:
 
 ```bash
-docker compose exec backend coverage run --source='.' manage.py test
-docker compose exec backend coverage report
+docker compose exec backend pytest --cov=. --cov-config=.coveragerc
 ```
+
+For a detailed coverage report:
+
+```bash
+docker compose exec backend pytest --cov=. --cov-config=.coveragerc --cov-report=term-missing
+```
+
+To generate and view an HTML coverage report:
+
+```bash
+docker compose exec backend pytest --cov=. --cov-config=.coveragerc --cov-report=html
+open backend/htmlcov/index.html
+```
+
+The project includes a `.coveragerc` file that excludes migrations, tests, admin files, and other boilerplate code from coverage reports.
+
+Or serve the report directly from the container:
+
+```bash
+docker compose exec backend python -m http.server -d htmlcov 9000
+```
+
+Then visit <http://localhost:9000> in your browser.
 
 ### Code Quality
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,26 @@
+codecov:
+  require_ci_to_pass: true
+
+coverage:
+  precision: 2
+  round: down
+  range: "70...100"
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+    patch:
+      default:
+        target: auto
+        threshold: 1%
+
+# Local .coveragerc file handles exclusions for local testing
+# This configuration is for the Codecov service and CI integration
+
+ignore:
+  - "**/migrations/"  # Exclude Django migrations
+  - "**/tests/"      # Exclude test files
+  - "**/admin.py"    # Exclude Django admin files
+  - "**/config/"     # Exclude configuration files
+  - "**/manage.py"   # Exclude Django management script


### PR DESCRIPTION
- Updated backend README with instructions for running tests and generating coverage reports using pytest.
- Added `.coveragerc` file to configure coverage reporting and exclude unnecessary files.
- Added `codecov.yml` for Codecov service configuration and CI integration.
- Updated `.gitignore` to exclude coverage files and directories.