### PR TITLE
Add 'uuid' field as readonly to SpeciesAdmin

### DIFF
--- a/backend/apps/taxonomy/admin.py
+++ b/backend/apps/taxonomy/admin.py
@@ -94,6 +94,7 @@ class SpeciesAdmin(admin.ModelAdmin):
         "scientific_name",
         "gbif_url_link",
         "tropical_plants_url_link",
+        "uuid",
     )
     fieldsets = (
         (
@@ -117,7 +118,7 @@ class SpeciesAdmin(admin.ModelAdmin):
             {"fields": ("gbif_id", "gbif_url_link", "tropical_plants_url_link")},
         ),
         ("Identification", {"fields": ("identified_by", "date")}),
-        ("Metadata", {"fields": ("id", "created_at", "updated_at")}),
+        ("Metadata", {"fields": ("id", "created_at", "updated_at", "uuid")}),
     )
 
     @admin.display(description="Life Form")


### PR DESCRIPTION
Let's put the UUID field back. It's useful after all, but we add it as readonly so it doesn't throw an error because it is non-editable. This should fix the FieldError.