### PR TITLE
Add ruff fix step to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,9 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install pre-commit
+        pip install pre-commit ruff
+    - name: Format files with ruff
+      run: ruff check . --fix
     - name: Cache pre-commit hooks
       uses: actions/cache@v4
       with:


### PR DESCRIPTION
The point is to prevent CI failures for files that can be fixed automatically in CI. This could happen when developers did not run pre-commit locally before opening a PR.