### PR TITLE
Fixes 132 --- improve chunk processing handling in import command

### DIFF
--- a/backend/config/settings/base.py
+++ b/backend/config/settings/base.py
@@ -228,11 +228,3 @@ SITE_ID = 1
 ACCOUNT_SIGNUP_FIELDS = ["email*", "password1*", "password2*"]
 ACCOUNT_LOGIN_METHODS = {"email"}
 ACCOUNT_EMAIL_VERIFICATION = "optional"
-
-
-# Settings for `import_initial_data` management command
-# Adjust based on available memory
-IMPORT_MEASUREMENTS_CHUNK_SIZE = env.int(
-    "IMPORT_MEASUREMENTS_CHUNK_SIZE", default=50000
-)
-IMPORT_CLIMATE_CHUNK_SIZE = env.int("IMPORT_CLIMATE_CHUNK_SIZE", default=50000)


### PR DESCRIPTION
This PR adds `chunksize` option for data import command, removes the old settings, and adds test coverage for the change.

No need to rebuild the database! This is simply an improvement for the next time anyone imports the data.

Closes #132