### PR TITLE
Normalize line endings across project files using .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,23 @@
+* text=auto
+
+# Force LF (Line Feed) as end-of-line for scripts
+*.sh text eol=lf
+*.py text eol=lf
+*.env text eol=lf
+Dockerfile text eol=lf
+
+# Markdown and documentation files
+*.md text eol=lf
+*.txt text eol=lf
+
+# JSON, YAML, and configuration files
+*.json text eol=lf
+*.yaml text eol=lf
+*.yml text eol=lf
+
+# Prevent line ending changes in binary files
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.pdf binary

--- a/backend/apps/core/management/commands/import_initial_data.py
+++ b/backend/apps/core/management/commands/import_initial_data.py
@@ -124,7 +124,7 @@ class Command(BaseCommand):
         parser.add_argument(
             "--chunksize",
             type=int,
-            default=10000,
+            default=25000,
             help="Number of records to process in each chunk of measurements and climate data",
         )
 

--- a/backend/apps/core/management/commands/import_initial_data.py
+++ b/backend/apps/core/management/commands/import_initial_data.py
@@ -124,7 +124,7 @@ class Command(BaseCommand):
         parser.add_argument(
             "--chunksize",
             type=int,
-            default=25000,
+            default=10000,
             help="Number of records to process in each chunk of measurements and climate data",
         )
 


### PR DESCRIPTION
This pull request ensures consistent line endings (LF) across the project by enforcing rules defined in the .gitattributes file. This change improves cross-platform compatibility and prevents future issues related to inconsistent line endings when collaborating between Windows, macOS, and Linux systems.

✅ Key changes:
- Added/updated .gitattributes to define LF endings for code and text files

- Applied git add --renormalize . to align tracked files with the specified line endings

- Ensured binary files are marked correctly to prevent corruption

No functional code changes were made — this update is purely structural to support cleaner collaboration and version control.