### PR TITLE
Geospatial Visualization by Zoom Levels

### DIFF
--- a/frontend/src/app/features/map/map.component.ts
+++ b/frontend/src/app/features/map/map.component.ts
@@ -5,19 +5,21 @@ import { HttpClient } from '@angular/common/http';
 import { HttpClientModule } from '@angular/common/http';
 import { forkJoin } from 'rxjs';
 
+interface GeoJsonProperties {
+  name: string;
+  statistics?: any;
+  environmental?: any;
+}
+
 @Component({
   selector: 'app-map',
   standalone: true,
   template: `
     <div class="flex flex-row h-full gap-4">
-      <!-- Details Panel -->
       <div class="bg-white rounded-lg shadow-lg border border-gray-200 p-4 w-[16rem]">
         <div class="grid grid-cols-1 gap-6">
-          <!-- Left Column -->
           <div>
             <h2 class="text-2xl font-bold text-gray-800 mb-4">{{ selectedRegion?.name || 'Ibagué Overview' }}</h2>
-
-            <!-- Tree Statistics -->
             <div class="space-y-4">
               <h3 class="text-lg font-semibold text-gray-700">Tree Statistics</h3>
               <div class="grid grid-cols-2 gap-x-8 gap-y-4">
@@ -40,8 +42,6 @@ import { forkJoin } from 'rxjs';
               </div>
             </div>
           </div>
-
-          <!-- Right Column -->
           <div>
             <h3 class="text-lg font-semibold text-gray-700 mb-4">Environmental Impact</h3>
             <div class="space-y-4">
@@ -55,14 +55,20 @@ import { forkJoin } from 'rxjs';
               </div>
             </div>
           </div>
+
+          <div *ngIf="selectedTree" class="mt-6 border-t pt-4">
+            <h3 class="text-lg font-semibold text-gray-700 mb-4">Selected Tree</h3>
+            <div class="space-y-2">
+              <p><span class="font-semibold text-gray-700">Common Name:</span> {{ selectedTree.commonName }}</p>
+              <p><span class="font-semibold text-gray-700">Scientific Name:</span> <em>{{ selectedTree.scientificName }}</em></p>
+              <p><span class="font-semibold text-gray-700">Life Form:</span> {{ selectedTree.lifeForm }}</p>
+              <p><span class="font-semibold text-gray-700">Neighborhood:</span> {{ selectedTree.neighborhood }}</p>
+            </div>
+          </div>
+
         </div>
       </div>
-
-      <!-- Map container -->
-      <div
-        id="map"
-        class="flex-1 rounded-lg shadow-lg border border-gray-200 min-h-[500px]"
-      ></div>
+      <div id="map" class="flex-1 rounded-lg shadow-lg border border-gray-200 min-h-[500px]"></div>
     </div>
   `,
   styles: [`
@@ -96,25 +102,27 @@ import { forkJoin } from 'rxjs';
   `],
   imports: [HttpClientModule, CommonModule]
 })
-
 export class MapComponent implements AfterViewInit, OnChanges {
   @Input() isSidebarOpen: boolean = true;
   private map!: L.Map;
   private shownLabels = new Set<string>();
-  
+  private pointLayer: L.LayerGroup = L.layerGroup();
+  private localityLayer: L.FeatureGroup = L.featureGroup();
+  private neighborhoodLayer: L.FeatureGroup = L.featureGroup();
+  private localityLabels: L.LayerGroup = L.layerGroup();  
+
   selectedRegion: any = {
     name: 'Ibagué Overview',
-    statistics: {
-      totalTrees: 0,
-      speciesCount: 0,
-      avgHeight: 0,
-      healthIndex: 0
-    },
-    environmental: {
-      co2Absorption: 0,
-      oxygenProduction: 0
-    }
+    statistics: { totalTrees: 0, speciesCount: 0, avgHeight: 0, healthIndex: 0 },
+    environmental: { co2Absorption: 0, oxygenProduction: 0 }
   };
+
+  selectedTree: {
+  commonName: string;
+  scientificName: string;
+  lifeForm: string;
+  neighborhood: string;
+} | null = null;
 
   constructor(private http: HttpClient) {}
 
@@ -134,28 +142,41 @@ export class MapComponent implements AfterViewInit, OnChanges {
     this.map = L.map('map').setView([4.4389, -75.2322], 14);
 
     L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-      maxZoom: 20,
-      attribution: '© OpenStreetMap contributors'
+      maxZoom: 23,
+      attribution: '© OpenStreetMap contributors',
+      errorTileUrl: 'https://upload.wikimedia.org/wikipedia/commons/a/ac/No_image_available.svg',
+      keepBuffer: 10
     }).addTo(this.map);
 
-    // List of IDs from 1 to 13
+    this.loadLocalities();
+    this.loadNeighborhoods();
+    this.map.removeLayer(this.neighborhoodLayer);
+
+    this.map.on('zoomend', () => {
+      this.toggleLayersByZoom();
+      this.loadPointsByZoom();
+    });
+
+    this.map.on('moveend', () => {
+      this.loadPointsByZoom();
+    });
+  }
+
+  private loadLocalities(): void {
     const comunaIds = Array.from({ length: 13 }, (_, i) => i + 1);
-    
-   // Make requests in parallel
+
     forkJoin(
-      comunaIds.map(id => 
-        this.http.get<any>(`http://localhost:8000/api/v1/places/localities/${id}/`)
-      )
+      comunaIds.map(id => this.http.get<any>(`http://localhost:8000/api/v1/places/localities/${id}/`))
     ).subscribe({
       next: (responses) => {
-        const allLayers = L.featureGroup();
+        this.shownLabels.clear();           
+        this.localityLabels.clearLayers();  
 
         responses.forEach(data => {
-          // Validate data before processing
           if (!data?.boundary?.coordinates) return;
 
-          const geojsonFeature = {
-            type: 'Feature' as const,
+          const geojsonFeature: GeoJSON.Feature = {
+            type: 'Feature',
             geometry: data.boundary,
             properties: {
               name: data.name || `Comuna ${data.id}`,
@@ -164,7 +185,7 @@ export class MapComponent implements AfterViewInit, OnChanges {
             }
           };
 
-          const geoLayer = L.geoJSON(geojsonFeature, {
+          const geoLayer = L.geoJSON(geojsonFeature as GeoJSON.GeoJsonObject, {
             style: {
               color: '#ffffff',
               weight: 1,
@@ -172,89 +193,186 @@ export class MapComponent implements AfterViewInit, OnChanges {
               fillOpacity: 0.5
             },
             onEachFeature: (feature, layer) => {
-              if (feature.properties) {
-                const comuna = feature.properties.name || 'Unknown Region';
+              const comuna = feature.properties?.name || 'Unknown Region';
 
-                if (!this.shownLabels.has(comuna)) {
-                  try {
-                    const bounds = (layer as L.Polygon).getBounds();
-                    if (bounds.isValid()) {
-                      const center = bounds.getCenter();
-
-                      const label = L.divIcon({
-                        className: 'region-label',
-                        html: `<div class="label-content">
-                                <div class="region-name">${comuna}</div>
-                                ${feature.properties.statistics ?
-                                  `<div class="statistics">${feature.properties.statistics.totalTrees || 'N/A'}</div>`
-                                  : ''}
-                              </div>`,
-                        iconSize: [200, 50],
-                        iconAnchor: [100, 25]
-                      });
-
-                      L.marker(center, {
-                        icon: label,
-                        interactive: false
-                      }).addTo(this.map);
-
-                      this.shownLabels.add(comuna);
-                    }
-                  } catch (error) {
-                    console.warn(`Error creando etiqueta para ${comuna}:`, error);
-                  }
-                }
-
-                layer.on({
-                  mouseover: (e) => {
-                    const layer = e.target;
-                    layer.setStyle({ fillOpacity: 0.7 });
-                  },
-                  mouseout: (e) => {
-                    const layer = e.target;
-                    layer.setStyle({ fillOpacity: 0.5 });
-                  },
-                  click: (e) => {
-                    const layer = e.target;
-                    const bounds = layer.getBounds();
-
-                    this.map.fitBounds(bounds, {
-                      padding: [10, 10],
-                      maxZoom: 16
+              if (!this.shownLabels.has(comuna)) {
+                try {
+                  const bounds = (layer as L.Polygon).getBounds();
+                  if (bounds.isValid()) {
+                    const center = bounds.getCenter();
+                    const label = L.divIcon({
+                      className: 'region-label',
+                      html: `<div class="label-content">
+                              <div class="region-name">${comuna}</div>
+                              ${feature.properties?.statistics ? 
+                                `<div class="statistics">${feature.properties.statistics.totalTrees || 'N/A'}</div>` : ''}
+                            </div>`,
+                      iconSize: [200, 50],
+                      iconAnchor: [100, 25]
                     });
 
-                    this.selectedRegion = {
-                      name: feature.properties.name || comuna,
-                      statistics: feature.properties.statistics || {
-                        totalTrees: 'N/A',
-                        speciesCount: 'N/A',
-                        avgHeight: 'N/A',
-                        healthIndex: 'N/A'
-                      },
-                      environmental: feature.properties.environmental || {
-                        co2Absorption: 'N/A',
-                        oxygenProduction: 'N/A'
-                      }
-                    };
+                    const marker = L.marker(center, {
+                      icon: label,
+                      interactive: false
+                    });
+
+                    this.localityLabels.addLayer(marker);  // ⬅️ Agrega al grupo
+
+                    this.shownLabels.add(comuna);
                   }
-                });
+                } catch (error) {
+                  console.warn(`Error creating label for ${comuna}:`, error);
+                }
               }
+
+              layer.on({
+                mouseover: (e) => {
+                  const l = e.target;
+                  l.setStyle({ fillOpacity: 0.7 });
+                },
+                mouseout: (e) => {
+                  const l = e.target;
+                  l.setStyle({ fillOpacity: 0.5 });
+                },
+                click: (e) => {
+                  const l = e.target;
+                  const bounds = l.getBounds();
+                  this.map.fitBounds(bounds, {
+                    padding: [10, 10],
+                    maxZoom: 16
+                  });
+
+                  this.selectedRegion = {
+                    name: comuna,
+                    statistics: feature.properties?.statistics || {
+                      totalTrees: 'N/A',
+                      speciesCount: 'N/A',
+                      avgHeight: 'N/A',
+                      healthIndex: 'N/A'
+                    },
+                    environmental: feature.properties?.environmental || {
+                      co2Absorption: 'N/A',
+                      oxygenProduction: 'N/A'
+                    }
+                  };
+                }
+              });
             }
           });
 
-          geoLayer.addTo(allLayers);
+          geoLayer.addTo(this.localityLayer);
         });
 
-        if (allLayers.getLayers().length > 0) {
-          allLayers.addTo(this.map);
-          this.map.fitBounds(allLayers.getBounds(), { padding: [40, 40] });
-          setTimeout(() => this.map.invalidateSize(), 100);
-        }
+        this.localityLayer.addTo(this.map);
+        this.localityLabels.addTo(this.map);  // ⬅️ Añade las etiquetas al mapa
       },
       error: (error) => {
-        console.error('Error cargando comunas:', error);
+        console.error('Error loading communes:', error);
       }
     });
+  }
+
+  private loadNeighborhoods(): void {
+    const barrioIds = Array.from({ length: 687 }, (_, i) => i + 1);
+
+    forkJoin(
+      barrioIds.map(id => this.http.get<any>(`http://localhost:8000/api/v1/places/neighborhoods/${id}/`))
+    ).subscribe({
+      next: (responses) => {
+        responses.forEach(data => {
+          if (!data?.boundary?.coordinates) return;
+          const geojsonFeature: GeoJSON.Feature = {
+            type: 'Feature',
+            geometry: data.boundary,
+            properties: { name: data.name || `Barrio ${data.id}` }
+          };
+          const geoLayer = L.geoJSON(geojsonFeature as GeoJSON.GeoJsonObject, {
+            style: {
+              color: '#3333ff',
+              weight: 1,
+              fillColor: '#32CD32',
+              fillOpacity: 0.3
+            }
+          });
+          geoLayer.addTo(this.neighborhoodLayer);
+        });
+      },
+      error: (error) => {
+        console.error('Error loading neighborhoods:', error);
+      }
+    });
+  }
+
+  private toggleLayersByZoom(): void {
+    const zoom = this.map.getZoom();
+
+    if (zoom >= 19) {
+      this.map.removeLayer(this.localityLayer);
+      this.map.removeLayer(this.localityLabels);  // ⬅️ Oculta etiquetas también
+      this.map.removeLayer(this.neighborhoodLayer);
+    } else if (zoom >= 17) {
+      this.map.addLayer(this.neighborhoodLayer);
+      this.map.removeLayer(this.localityLayer);
+      this.map.removeLayer(this.localityLabels);
+    } else {
+      this.map.addLayer(this.localityLayer);
+      this.map.addLayer(this.localityLabels);     // ⬅️ Muestra etiquetas con capas
+      this.map.removeLayer(this.neighborhoodLayer);
+    }
+  }
+
+  private loadPointsByZoom(): void {
+    const zoom = this.map.getZoom();
+    if (zoom < 19) {
+      this.removePoints();
+      return;
+    }
+
+    const bounds = this.map.getBounds();
+    const minLat = bounds.getSouth();
+    const maxLat = bounds.getNorth();
+    const minLon = bounds.getWest();
+    const maxLon = bounds.getEast();
+
+    const url = `http://localhost:8000/api/v1/biodiversity/records/bbox/?min_lon=${minLon}&min_lat=${minLat}&max_lon=${maxLon}&max_lat=${maxLat}`;
+
+    this.http.get<any[]>(url).subscribe({
+      next: (data) => {
+        this.pointLayer.clearLayers();
+
+        data.forEach(record => {
+          if (record.latitude && record.longitude) {
+            const marker = L.circleMarker([record.latitude, record.longitude], {
+              radius: 5,
+              color: '#000000',
+              weight: 1,
+              fillColor: '#006400',
+              fillOpacity: 0.6
+            });
+
+            marker.on('click', () => {
+              this.selectedTree = {
+                commonName: record.common_name || 'N/A',
+                scientificName: record.species?.scientific_name || 'N/A',
+                lifeForm: record.species?.life_form || 'N/A',
+                neighborhood: record.neighborhood?.name || 'N/A'
+              };
+            });
+
+            marker.addTo(this.pointLayer);
+          }
+        });
+
+        this.pointLayer.addTo(this.map);
+      },
+      error: (error) => {
+        console.error('Error loading points:', error);
+      }
+    });
+  }
+
+  private removePoints(): void {
+    this.map.removeLayer(this.pointLayer);
   }
 }
 


### PR DESCRIPTION
This pull request introduces dynamic map behavior based on zoom levels, allowing for a more intuitive and layered geospatial experience. The following features are included:

- Display of communes (localities) at lower zoom levels with labeled polygons.

- Automatic switch to neighborhoods at medium zoom levels.

- Display of individual trees as point markers at higher zoom levels.

- Interactive panels update with statistical or tree-specific information upon clicking each element.

- Improved visual clarity and performance across all map layers.

These enhancements support better exploration of urban trees ecosystem.