### PR TITLE
Add Interactive Map Display for Urban Tree Observations by Neighborhood

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,16 @@ docker compose exec backend python manage.py createsuperuser
 
 ### Initial Data Import
 
+### Initial Data Import
+
+To get the initial data, you can use one of the following links:
+
+1. [Google Drive](https://drive.google.com/drive/folders/1EgslMmVYdvtSXS22wDYCDCroOLV7TqmY?usp=sharing)
+2. [Hugging Face](https://huggingface.co/datasets/juanpac96/urban_tree_census_data)
+
+
+
+
 To import initial data into the database:
 
 1. Download the latest version of the CSV snd JSON files from the project's shared Google Drive.

--- a/frontend/src/app/features/dashboard/dashboard.component.ts
+++ b/frontend/src/app/features/dashboard/dashboard.component.ts
@@ -125,24 +125,24 @@ import { Chart } from 'chart.js/auto';
             <h3 class="text-lg font-medium text-gray-700 mb-3">Top Species Distribution</h3>
             <div class="space-y-2">
               <div class="flex flex-col">
-                <span class="text-sm">Ceiba pentandra</span>
-                <div class="flex items-center mt-1">
-                  <div class="h-2 bg-green-500 rounded" style="width: 15%"></div>
-                  <span class="ml-2 text-xs">15,000 (15%)</span>
-                </div>
-              </div>
-              <div class="flex flex-col">
-                <span class="text-sm">Quercus humboldtii</span>
-                <div class="flex items-center mt-1">
-                  <div class="h-2 bg-green-500 rounded" style="width: 12%"></div>
-                  <span class="ml-2 text-xs">12,000 (12%)</span>
-                </div>
-              </div>
-              <div class="flex flex-col">
                 <span class="text-sm">Tabebuia rosea</span>
                 <div class="flex items-center mt-1">
+                  <div class="h-2 bg-green-500 rounded" style="width: 15%"></div>
+                  <span class="ml-2 text-xs">9,463 (9.76%)</span>
+                </div>
+              </div>
+              <div class="flex flex-col">
+                <span class="text-sm">Dypsis lutescens</span>
+                <div class="flex items-center mt-1">
+                  <div class="h-2 bg-green-500 rounded" style="width: 12%"></div>
+                  <span class="ml-2 text-xs">7,430 (7.66%)</span>
+                </div>
+              </div>
+              <div class="flex flex-col">
+                <span class="text-sm">Syzygium malaccense</span>
+                <div class="flex items-center mt-1">
                   <div class="h-2 bg-green-500 rounded" style="width: 10%"></div>
-                  <span class="ml-2 text-xs">10,000 (10%)</span>
+                  <span class="ml-2 text-xs">7,175 (7.40%)</span>
                 </div>
               </div>
             </div>
@@ -448,55 +448,76 @@ export class DashboardComponent implements OnInit {
     });
   }
 
-  private createGeoDistributionChart() {
-    const ctx = document.getElementById('geoDistributionChart') as HTMLCanvasElement;
-    if (!ctx) return;
-    
-    new Chart(ctx, {
-      type: 'bar',
-      data: {
-        labels: ['Ibagué', 'Medellín', 'Cali', 'Barranquilla', 'Cartagena'],
-        datasets: [{
-          label: 'Trees',
-          data: [20000, 18000, 15000, 12000, 10000],
-          backgroundColor: '#60a5fa',
-          borderWidth: 0,
-          borderRadius: 4
-        }]
-      },
-      options: {
-        scales: {
-          y: {
-            beginAtZero: true,
-            grid: {
-              display: true,
-              color: 'rgba(0, 0, 0, 0.05)'
-            },
-            ticks: {
-              font: {
-                size: 10
-              }
+private createGeoDistributionChart() {
+  const ctx = document.getElementById('geoDistributionChart') as HTMLCanvasElement;
+  if (!ctx) return;
+
+  new Chart(ctx, {
+    type: 'bar',
+    data: {
+      labels: [
+        'Comuna 1', 'Comuna 2', 'Comuna 3', 'Comuna 4',
+        'Comuna 5', 'Comuna 6', 'Comuna 7', 'Comuna 8',
+        'Comuna 9', 'Comuna 10', 'Comuna 11', 'Comuna 12',
+        'Comuna 13', 'Comuna 14'
+      ],
+      datasets: [{
+        label: 'Total Trees',
+        data: [
+          3269, 2311, 2476, 3220,
+          8492, 5590, 10890, 16893,
+          13503, 7768, 9087, 3658,
+          4077, 5709
+        ],
+        backgroundColor: '#2F7B3D',
+        borderRadius: 4,
+        borderSkipped: false
+      }]
+    },
+    options: {
+      responsive: true,
+      maintainAspectRatio: false,
+      scales: {
+        y: {
+          beginAtZero: true,
+          grid: {
+            display: true,
+            color: 'rgba(0, 0, 0, 0.05)'
+          },
+          ticks: {
+            font: {
+              size: 10
             }
           },
-          x: {
-            grid: {
-              display: false
-            },
-            ticks: {
-              font: {
-                size: 10
-              }
-            }
+          title: {
+            display: true,
+            text: 'Total de árboles'
           }
         },
-        plugins: {
-          legend: {
+        x: {
+          grid: {
             display: false
+          },
+          ticks: {
+            font: {
+              size: 10
+            }
+          },
+          title: {
+            display: true,
+            text: 'Comunas'
           }
         }
+      },
+      plugins: {
+        legend: {
+          display: false
+        }
       }
-    });
-  }
+    }
+  });
+}
+
 
   private createTemperatureTrendsChart() {
     const ctx = document.getElementById('temperatureTrendsChart') as HTMLCanvasElement;

--- a/frontend/src/app/features/map/map.component.ts
+++ b/frontend/src/app/features/map/map.component.ts
@@ -24,11 +24,11 @@ interface GeoJsonProperties {
               <h3 class="text-lg font-semibold text-gray-700">Tree Statistics</h3>
               <div class="grid grid-cols-2 gap-x-8 gap-y-4">
                 <div>
-                  <p class="text-2xl font-bold text-green-700">{{ selectedRegion?.statistics?.totalTrees || '96,943' }}</p>
+                  <p class="text-2xl font-bold text-green-700">{{ selectedRegion?.statistics?.totalTrees || '101,283' }}</p>
                   <p class="text-sm text-gray-600">Total Trees</p>
                 </div>
                 <div>
-                  <p class="text-2xl font-bold text-green-700">{{ selectedRegion?.statistics?.speciesCount || '439' }}</p>
+                  <p class="text-2xl font-bold text-green-700">{{ selectedRegion?.statistics?.speciesCount || '407' }}</p>
                   <p class="text-sm text-gray-600">Species Count</p>
                 </div>
                 <div>
@@ -109,7 +109,18 @@ export class MapComponent implements AfterViewInit, OnChanges {
   private pointLayer: L.LayerGroup = L.layerGroup();
   private localityLayer: L.FeatureGroup = L.featureGroup();
   private neighborhoodLayer: L.FeatureGroup = L.featureGroup();
-  private localityLabels: L.LayerGroup = L.layerGroup();  
+  private localityLabels: L.LayerGroup = L.layerGroup();
+  private comunaCoords: Record<number, [number, number]> = {
+    1: [4.444155773015618, -75.23969864493603],
+    3: [4.44314777205183, -75.2229990060045],
+    5: [4.4414122157367455, -75.19866063473717],
+    6: [4.448946582667143, -75.19216298371211],
+    7: [4.447054612850441, -75.15486397564855],
+    8: [4.439440632646043, -75.17641129077383],
+    9: [4.43193067187494, -75.1956365655411],
+    11: [4.428197280276076, -75.2300237422717],
+    12: [4.429748394627603, -75.24106640852413]
+  };
 
   selectedRegion: any = {
     name: 'Ibagué Overview',
@@ -118,11 +129,11 @@ export class MapComponent implements AfterViewInit, OnChanges {
   };
 
   selectedTree: {
-  commonName: string;
-  scientificName: string;
-  lifeForm: string;
-  neighborhood: string;
-} | null = null;
+    commonName: string;
+    scientificName: string;
+    lifeForm: string;
+    neighborhood: string;
+  } | null = null;
 
   constructor(private http: HttpClient) {}
 
@@ -169,8 +180,8 @@ export class MapComponent implements AfterViewInit, OnChanges {
       comunaIds.map(id => this.http.get<any>(`http://localhost:8000/api/v1/places/localities/${id}/`))
     ).subscribe({
       next: (responses) => {
-        this.shownLabels.clear();           
-        this.localityLabels.clearLayers();  
+        this.shownLabels.clear();
+        this.localityLabels.clearLayers();
 
         responses.forEach(data => {
           if (!data?.boundary?.coordinates) return;
@@ -197,29 +208,36 @@ export class MapComponent implements AfterViewInit, OnChanges {
 
               if (!this.shownLabels.has(comuna)) {
                 try {
-                  const bounds = (layer as L.Polygon).getBounds();
-                  if (bounds.isValid()) {
-                    const center = bounds.getCenter();
-                    const label = L.divIcon({
-                      className: 'region-label',
-                      html: `<div class="label-content">
+                  const comunaId = data.id;
+                  const manualCoords = this.comunaCoords[comunaId];
+
+                  let center: L.LatLng;
+                  if (manualCoords) {
+                    center = L.latLng(manualCoords[0], manualCoords[1]);
+                  } else {
+                    const bounds = (layer as L.Polygon).getBounds();
+                    if (!bounds.isValid()) return;
+                    center = bounds.getCenter();
+                  }
+
+                  const label = L.divIcon({
+                    className: 'region-label',
+                    html: `<div class="label-content">
                               <div class="region-name">${comuna}</div>
-                              ${feature.properties?.statistics ? 
+                              ${feature.properties?.statistics ?
                                 `<div class="statistics">${feature.properties.statistics.totalTrees || 'N/A'}</div>` : ''}
                             </div>`,
-                      iconSize: [200, 50],
-                      iconAnchor: [100, 25]
-                    });
+                    iconSize: [200, 50],
+                    iconAnchor: [100, 25]
+                  });
 
-                    const marker = L.marker(center, {
-                      icon: label,
-                      interactive: false
-                    });
+                  const marker = L.marker(center, {
+                    icon: label,
+                    interactive: false
+                  });
 
-                    this.localityLabels.addLayer(marker);  // ⬅️ Agrega al grupo
-
-                    this.shownLabels.add(comuna);
-                  }
+                  this.localityLabels.addLayer(marker);
+                  this.shownLabels.add(comuna);
                 } catch (error) {
                   console.warn(`Error creating label for ${comuna}:`, error);
                 }
@@ -264,7 +282,7 @@ export class MapComponent implements AfterViewInit, OnChanges {
         });
 
         this.localityLayer.addTo(this.map);
-        this.localityLabels.addTo(this.map);  // ⬅️ Añade las etiquetas al mapa
+        this.localityLabels.addTo(this.map);
       },
       error: (error) => {
         console.error('Error loading communes:', error);
@@ -308,7 +326,7 @@ export class MapComponent implements AfterViewInit, OnChanges {
 
     if (zoom >= 19) {
       this.map.removeLayer(this.localityLayer);
-      this.map.removeLayer(this.localityLabels);  // ⬅️ Oculta etiquetas también
+      this.map.removeLayer(this.localityLabels);
       this.map.removeLayer(this.neighborhoodLayer);
     } else if (zoom >= 17) {
       this.map.addLayer(this.neighborhoodLayer);
@@ -316,7 +334,7 @@ export class MapComponent implements AfterViewInit, OnChanges {
       this.map.removeLayer(this.localityLabels);
     } else {
       this.map.addLayer(this.localityLayer);
-      this.map.addLayer(this.localityLabels);     // ⬅️ Muestra etiquetas con capas
+      this.map.addLayer(this.localityLabels);
       this.map.removeLayer(this.neighborhoodLayer);
     }
   }
@@ -375,4 +393,5 @@ export class MapComponent implements AfterViewInit, OnChanges {
     this.map.removeLayer(this.pointLayer);
   }
 }
+
 


### PR DESCRIPTION
This pull request introduces a new feature to visualize the distribution of urban trees at the neighborhood level. Key updates include:

- Display of neighborhood polygons using GeoJSON data.

- Layer toggling based on zoom level to improve map readability.

- Integration of customized label placement for selected communes.

- Minor improvements to the README.md, including data source links (Google Drive & Hugging Face).